### PR TITLE
Chore: Enable module interoperability in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
Tentatively enabled module interoperability across the application to suppress TS151001 warnings when running `npm test`

If issues arise, this can safely be reverted without adverse affects as the application ran successfully, including the tests, before and after enabling this feature.